### PR TITLE
Improve stuffs about test settings and autoload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+tmp/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '7.4'
 
 script:
+  - composer install -n
   - phpunit --coverage-clover=coverage.xml --configuration=phpunit.xml
 
 after_script:

--- a/Tests/CurlWrapperUnitTest.php
+++ b/Tests/CurlWrapperUnitTest.php
@@ -1,8 +1,11 @@
 <?php
 
-require_once(__DIR__.'/../CurlWrapper.php');
+namespace Mezon\CustomClient\Tests;
 
-class CurlWrapperUnitTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Mezon\CustomClient\CurlWrapper;
+
+class CurlWrapperUnitTest extends TestCase
 {
 
     /**
@@ -10,7 +13,7 @@ class CurlWrapperUnitTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetRequest()
     {
-        list ($body, $code) = \Mezon\CustomClient\CurlWrapper::sendRequest('http://google.com', [], 'GET');
+        list ($body, $code) = CurlWrapper::sendRequest('http://google.com', [], 'GET');
 
         $this->assertStringContainsString('', $body, 'Invalid HTML was returned');
         $this->assertEquals(301, $code, 'Invalid HTTP code');
@@ -21,7 +24,7 @@ class CurlWrapperUnitTest extends \PHPUnit\Framework\TestCase
      */
     public function testPostRequest()
     {
-        list ($body, $code) = \Mezon\CustomClient\CurlWrapper::sendRequest(
+        list ($body, $code) = CurlWrapper::sendRequest(
             'http://google.com',
             [],
             'POST',

--- a/Tests/CustomClientTest.php
+++ b/Tests/CustomClientTest.php
@@ -1,8 +1,11 @@
 <?php
 
-require_once(__DIR__.'/../CustomClient.php');
+namespace Mezon\CustomClient\Tests;
 
-class CustomClientTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Mezon\CustomClient\CustomClient;
+
+class CustomClientTest extends TestCase
 {
 
     /**
@@ -10,7 +13,7 @@ class CustomClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetMethod()
     {
-        $client = new \Mezon\CustomClient\CustomClient('http://yandex.ru/');
+        $client = new CustomClient('http://yandex.ru/');
 
         $client->sendGetRequest('unexisting');
 
@@ -22,7 +25,7 @@ class CustomClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testPostMethod()
     {
-        $client = new \Mezon\CustomClient\CustomClient('http://yandex.ru/');
+        $client = new CustomClient('http://yandex.ru/');
 
         $client->sendPostRequest('unexisting');
 

--- a/Tests/CustomClientUnitTest.php
+++ b/Tests/CustomClientUnitTest.php
@@ -1,18 +1,12 @@
 <?php
-require_once (__DIR__ . '/../CustomClient.php');
 
+namespace Mezon\CustomClient\Tests;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
 use Mezon\CustomClient\CustomClient;
 
-class TestClient extends CustomClient
-{
-
-    public function getCommonHeadersPublic(): array
-    {
-        return parent::getCommonHeaders();
-    }
-}
-
-class CustomClientUnitTest extends \PHPUnit\Framework\TestCase
+class CustomClientUnitTest extends TestCase
 {
 
     /**

--- a/Tests/TestClient.php
+++ b/Tests/TestClient.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Mezon\CustomClient\Tests;
+
+use Mezon\CustomClient\CustomClient;
+
+class TestClient extends CustomClient
+{
+
+    public function getCommonHeadersPublic(): array
+    {
+        return parent::getCommonHeaders();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2.0",
+		"php": ">=7.2.0"
+	},
+	"require-dev": {
 		"phpunit/phpunit": "^8.5"
 	},
 	"support": {
@@ -27,8 +29,13 @@
 			"Mezon\\CustomClient\\": ""
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"Mezon\\CustomClient\\Tests\\": "Tests/"
+		}
+	},
 	"scripts": {
-		"post-update-cmd": "php ./vendor/phpunit/phpunit/phpunit",
-		"test": "php ./vendor/phpunit/phpunit/phpunit"
+		"post-update-cmd": "php ./vendor/bin/phpunit",
+		"test": "php ./vendor/bin/phpunit"
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+	bootstrap="./vendor/autoload.php"
 	backupGlobals="false" colors="true">
 	<php>
 		<ini name="error_reporting" value="-1" />


### PR DESCRIPTION
# Changed log
- Add `.gitignore` file to define some files and folders to be not under Git version control.
- Add EOF (end of file) for some files.
- Remove manual loading specific files for some test classes.
Using the Composer `vendor/autoload.php` file instead.
- Define the test namespace for every PHP classes on `autoload-dev` block inside `composer.json` file.
- Define `phpunit/phpunit` package on `require-dev` block inside `composer.json` file.
- Define the `bootstrap` attribute to be `./vendor/autoload.php` on `phpunit.xml` to let PHPUnit will load all required PHP files and classes during PHPUnit tests executing.
- Split `TestClient` class to let one PHP file has only one class.